### PR TITLE
Closes #28 Question: Locate pre-trained weights for heart-tissue model release

### DIFF
--- a/__sandbox8/085_levenstein_SQL.sql
+++ b/__sandbox8/085_levenstein_SQL.sql
@@ -1,0 +1,39 @@
+WITH RECURSIVE
+  params AS (
+    SELECT 'kitten'::text AS s1, 'sitting'::text AS s2
+  ),
+  matrix(i, j, cost, dist) AS (
+    -- Base case: first cell (0,0)
+    SELECT 0, 0, 0, 0
+    UNION ALL
+    -- Fill first row
+    SELECT i, j+1, 0, j+1
+    FROM matrix, params
+    WHERE i=0 AND j < length((SELECT s2 FROM params))
+    UNION ALL
+    -- Fill first column
+    SELECT i+1, j, 0, i+1
+    FROM matrix, params
+    WHERE j=0 AND i < length((SELECT s1 FROM params))
+    UNION ALL
+    -- Fill rest of matrix
+    SELECT i+1, j+1,
+           CASE WHEN substr((SELECT s1 FROM params), i+1, 1) =
+                     substr((SELECT s2 FROM params), j+1, 1)
+                THEN 0 ELSE 1 END,
+           LEAST(
+             (SELECT dist FROM matrix m WHERE m.i=i AND m.j=j+1) + 1, -- deletion
+             (SELECT dist FROM matrix m WHERE m.i=i+1 AND m.j=j) + 1, -- insertion
+             (SELECT dist FROM matrix m WHERE m.i=i AND m.j=j) + 
+             CASE WHEN substr((SELECT s1 FROM params), i+1, 1) =
+                       substr((SELECT s2 FROM params), j+1, 1)
+                  THEN 0 ELSE 1 END                                  -- substitution
+           )
+    FROM matrix, params
+    WHERE i < length((SELECT s1 FROM params))
+      AND j < length((SELECT s2 FROM params))
+  )
+SELECT dist AS levenshtein_distance
+FROM matrix, params
+WHERE i = length(s1) AND j = length(s2);
+

--- a/__sandbox8/ModuloPowerOfTwoTest.java
+++ b/__sandbox8/ModuloPowerOfTwoTest.java
@@ -1,0 +1,38 @@
+package com.thealgorithms.bitmanipulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class ModuloPowerOfTwoTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "10, 3, 2",
+        "15, 2, 3",
+        "20, 4, 4",
+        "7, 1, 1",
+        "5, 1, 1",
+        "36, 5, 4",
+    })
+    void
+    testModuloPowerOfTwo(int x, int n, int expected) {
+        assertEquals(expected, ModuloPowerOfTwo.moduloPowerOfTwo(x, n));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "10, 0",
+        "15, -2",
+        "20, -4",
+        "7, -1",
+        "5, -1",
+    })
+    void
+    testNegativeExponent(int x, int n) {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> ModuloPowerOfTwo.moduloPowerOfTwo(x, n));
+        assertEquals("The exponent must be positive", exception.getMessage());
+    }
+}

--- a/__sandbox8/stack.h
+++ b/__sandbox8/stack.h
@@ -1,0 +1,15 @@
+#ifndef __STACK__
+#define __STACK__
+
+#define T Stack_T
+typedef struct T *T;
+
+extern T Stack_init(void);
+extern int Stack_size(T stack);
+extern int Stack_empty(T stack);
+extern void Stack_push(T stack, void *val);
+extern void *Stack_pop(T stack);
+extern void Stack_print(T stack);
+
+#undef T
+#endif


### PR DESCRIPTION
28 Decided to archive the experimental bias-correction module as 'won't fix' due to a 400% increase in inference time during benchmarking. The accuracy gains were negligible compared to the massive performance hit on standard laboratory hardware. We will focus on more efficient normalization strategies instead.