### PR TITLE
Closes #68 Close wontfix: Support for deprecated API version

### DIFF
--- a/__dev7/CompFilt.hs
+++ b/__dev7/CompFilt.hs
@@ -1,0 +1,48 @@
+module Robotics.ComplementaryFilter.CompFilt where
+
+import Robotics.ComplementaryFilter.TestData
+
+-- Utility functions to extract X, Y, Z components from 3D vector.
+getX :: (a, a, a) -> a
+getX (x,_,_) = x
+
+getY :: (a, a, a) -> a
+getY (_,y,_) = y
+
+getZ :: (a, a, a) -> a
+getZ (_,_,z) = z
+
+-- Extract accel data from list of floats
+getAccel :: (RealFloat a) => [a] -> (a, a, a)
+getAccel [] = (0, 0, 0)
+getAccel s = if length s >= 6
+                then (s!!0, s!!1, s!!2)
+                else (0, 0, 0)
+
+-- Extract gyro data from a lsit of floats
+getGyro :: (RealFloat a) => [a] -> (a, a, a)
+getGyro s = if length s >= 6 
+               then (s!!3, s!!4, s!!5)
+               else (0, 0, 0)
+
+-- Function to calculate tilt angle from accelerometer reading.
+-- By default the tilt measurement is made around the Z axis.
+accelTiltAngle :: (RealFloat a) => (a, a, a) -> a
+accelTiltAngle (_, y, z) = (atan2 z y)*180.0/pi
+
+
+-- Complementary filter, uses the scanl pattern.
+compFilt :: (RealFloat a) => [a] -> [a] -> a -> a -> [a]
+compFilt ωs θ_accs α δt = scanl (\θ (ω, θ_acc) -> α*(θ + ω*δt) + (1-α)*θ_acc) 
+                                (head θ_accs)
+                                (zip ωs θ_accs)
+
+-- Calculate tilts
+calcTilt :: (RealFloat a) => [(a, a, a)] -> [(a, a, a)] -> a -> a -> [a]
+calcTilt accel gyro α δt = compFilt (map getX gyro) (map accelTiltAngle accel) α δt
+
+main = do
+    let accels = map getAccel testData
+    let gyros  = map getGyro testData
+    let tilts = calcTilt accels gyros 0.95 0.01
+    print tilts

--- a/__dev7/DiceCoefficient.js
+++ b/__dev7/DiceCoefficient.js
@@ -1,0 +1,50 @@
+/* The Sørensen–Dice coefficient is a statistic used to gauge the similarity of two samples.
+ * Applied to strings, it can give you a value between 0 and 1 (included) which tells you how similar they are.
+ * Dice coefficient is calculated by comparing the bigrams of both strings,
+ * a bigram is a substring of the string of length 2.
+ * read more: https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient
+ */
+
+// Time complexity: O(m + n), m and n being the sizes of string A and string B
+
+// Find the bistrings of a string and return a hashmap (key => bistring, value => count)
+function mapBigrams(string) {
+  const bigrams = new Map()
+  for (let i = 0; i < string.length - 1; i++) {
+    const bigram = string.substring(i, i + 2)
+    const count = bigrams.get(bigram)
+    bigrams.set(bigram, (count || 0) + 1)
+  }
+  return bigrams
+}
+
+// Calculate the number of common bigrams between a map of bigrams and a string
+
+function countCommonBigrams(bigrams, string) {
+  let count = 0
+  for (let i = 0; i < string.length - 1; i++) {
+    const bigram = string.substring(i, i + 2)
+    if (bigrams.has(bigram)) count++
+  }
+  return count
+}
+
+// Calculate Dice coeff of 2 strings
+function diceCoefficient(stringA, stringB) {
+  if (stringA === stringB) return 1
+  else if (stringA.length < 2 || stringB.length < 2) return 0
+
+  const bigramsA = mapBigrams(stringA)
+
+  const lengthA = stringA.length - 1
+  const lengthB = stringB.length - 1
+
+  let dice = (2 * countCommonBigrams(bigramsA, stringB)) / (lengthA + lengthB)
+
+  // cut 0.xxxxxx to 0.xx for simplicity
+  dice = Math.floor(dice * 100) / 100
+
+  return dice
+}
+
+export { diceCoefficient }

--- a/__dev7/KthElementFinderTest.java
+++ b/__dev7/KthElementFinderTest.java
@@ -1,0 +1,19 @@
+package com.thealgorithms.datastructures.heaps;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class KthElementFinderTest {
+    @Test
+    public void testFindKthLargest() {
+        int[] nums = {3, 2, 1, 5, 6, 4};
+        assertEquals(5, KthElementFinder.findKthLargest(nums, 2));
+    }
+
+    @Test
+    public void testFindKthSmallest() {
+        int[] nums = {7, 10, 4, 3, 20, 15};
+        assertEquals(7, KthElementFinder.findKthSmallest(nums, 3));
+    }
+}

--- a/__dev7/convert_number_to_words.py
+++ b/__dev7/convert_number_to_words.py
@@ -1,0 +1,205 @@
+from enum import Enum
+from typing import Literal
+
+
+class NumberingSystem(Enum):
+    SHORT = (
+        (15, "quadrillion"),
+        (12, "trillion"),
+        (9, "billion"),
+        (6, "million"),
+        (3, "thousand"),
+        (2, "hundred"),
+    )
+
+    LONG = (
+        (15, "billiard"),
+        (9, "milliard"),
+        (6, "million"),
+        (3, "thousand"),
+        (2, "hundred"),
+    )
+
+    INDIAN = (
+        (14, "crore crore"),
+        (12, "lakh crore"),
+        (7, "crore"),
+        (5, "lakh"),
+        (3, "thousand"),
+        (2, "hundred"),
+    )
+
+    @classmethod
+    def max_value(cls, system: str) -> int:
+        """
+        Gets the max value supported by the given number system.
+
+        >>> NumberingSystem.max_value("short") == 10**18 - 1
+        True
+        >>> NumberingSystem.max_value("long") == 10**21 - 1
+        True
+        >>> NumberingSystem.max_value("indian") == 10**19 - 1
+        True
+        """
+        match system_enum := cls[system.upper()]:
+            case cls.SHORT:
+                max_exp = system_enum.value[0][0] + 3
+            case cls.LONG:
+                max_exp = system_enum.value[0][0] + 6
+            case cls.INDIAN:
+                max_exp = 19
+            case _:
+                raise ValueError("Invalid numbering system")
+        return 10**max_exp - 1
+
+
+class NumberWords(Enum):
+    ONES = {  # noqa: RUF012
+        0: "",
+        1: "one",
+        2: "two",
+        3: "three",
+        4: "four",
+        5: "five",
+        6: "six",
+        7: "seven",
+        8: "eight",
+        9: "nine",
+    }
+
+    TEENS = {  # noqa: RUF012
+        0: "ten",
+        1: "eleven",
+        2: "twelve",
+        3: "thirteen",
+        4: "fourteen",
+        5: "fifteen",
+        6: "sixteen",
+        7: "seventeen",
+        8: "eighteen",
+        9: "nineteen",
+    }
+
+    TENS = {  # noqa: RUF012
+        2: "twenty",
+        3: "thirty",
+        4: "forty",
+        5: "fifty",
+        6: "sixty",
+        7: "seventy",
+        8: "eighty",
+        9: "ninety",
+    }
+
+
+def convert_small_number(num: int) -> str:
+    """
+    Converts small, non-negative integers with irregular constructions in English (i.e.,
+    numbers under 100) into words.
+
+    >>> convert_small_number(0)
+    'zero'
+    >>> convert_small_number(5)
+    'five'
+    >>> convert_small_number(10)
+    'ten'
+    >>> convert_small_number(15)
+    'fifteen'
+    >>> convert_small_number(20)
+    'twenty'
+    >>> convert_small_number(25)
+    'twenty-five'
+    >>> convert_small_number(-1)
+    Traceback (most recent call last):
+    ...
+    ValueError: This function only accepts non-negative integers
+    >>> convert_small_number(123)
+    Traceback (most recent call last):
+    ...
+    ValueError: This function only converts numbers less than 100
+    """
+    if num < 0:
+        raise ValueError("This function only accepts non-negative integers")
+    if num >= 100:
+        raise ValueError("This function only converts numbers less than 100")
+    tens, ones = divmod(num, 10)
+    if tens == 0:
+        return NumberWords.ONES.value[ones] or "zero"
+    if tens == 1:
+        return NumberWords.TEENS.value[ones]
+    return (
+        NumberWords.TENS.value[tens]
+        + ("-" if NumberWords.ONES.value[ones] else "")
+        + NumberWords.ONES.value[ones]
+    )
+
+
+def convert_number(
+    num: int, system: Literal["short", "long", "indian"] = "short"
+) -> str:
+    """
+    Converts an integer to English words.
+
+    :param num: The integer to be converted
+    :param system: The numbering system (short, long, or Indian)
+
+    >>> convert_number(0)
+    'zero'
+    >>> convert_number(1)
+    'one'
+    >>> convert_number(100)
+    'one hundred'
+    >>> convert_number(-100)
+    'negative one hundred'
+    >>> convert_number(123_456_789_012_345) # doctest: +NORMALIZE_WHITESPACE
+    'one hundred twenty-three trillion four hundred fifty-six billion
+    seven hundred eighty-nine million twelve thousand three hundred forty-five'
+    >>> convert_number(123_456_789_012_345, "long") # doctest: +NORMALIZE_WHITESPACE
+    'one hundred twenty-three thousand four hundred fifty-six milliard
+    seven hundred eighty-nine million twelve thousand three hundred forty-five'
+    >>> convert_number(12_34_56_78_90_12_345, "indian") # doctest: +NORMALIZE_WHITESPACE
+    'one crore crore twenty-three lakh crore
+    forty-five thousand six hundred seventy-eight crore
+    ninety lakh twelve thousand three hundred forty-five'
+    >>> convert_number(10**18)
+    Traceback (most recent call last):
+    ...
+    ValueError: Input number is too large
+    >>> convert_number(10**21, "long")
+    Traceback (most recent call last):
+    ...
+    ValueError: Input number is too large
+    >>> convert_number(10**19, "indian")
+    Traceback (most recent call last):
+    ...
+    ValueError: Input number is too large
+    """
+    word_groups = []
+
+    if num < 0:
+        word_groups.append("negative")
+        num *= -1
+
+    if num > NumberingSystem.max_value(system):
+        raise ValueError("Input number is too large")
+
+    for power, unit in NumberingSystem[system.upper()].value:
+        digit_group, num = divmod(num, 10**power)
+        if digit_group > 0:
+            word_group = (
+                convert_number(digit_group, system)
+                if digit_group >= 100
+                else convert_small_number(digit_group)
+            )
+            word_groups.append(f"{word_group} {unit}")
+    if num > 0 or not word_groups:  # word_groups is only empty if input num was 0
+        word_groups.append(convert_small_number(num))
+    return " ".join(word_groups)
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+
+    print(f"{convert_number(123456789) = }")

--- a/__dev7/zellers_congruence_algorithm.rs
+++ b/__dev7/zellers_congruence_algorithm.rs
@@ -1,0 +1,54 @@
+// returns the day of the week from the Gregorian Date
+
+pub fn zellers_congruence_algorithm(date: i32, month: i32, year: i32, as_string: bool) -> String {
+    let q = date;
+    let (m, y) = if month < 3 {
+        (month + 12, year - 1)
+    } else {
+        (month, year)
+    };
+    let day: i32 =
+        (q + (26 * (m + 1) / 10) + (y % 100) + ((y % 100) / 4) + ((y / 100) / 4) + (5 * (y / 100)))
+            % 7;
+    if as_string {
+        number_to_day(day)
+    } else {
+        day.to_string()
+    }
+    /* Note that the day follows the following guidelines:
+    0 = Saturday
+    1 = Sunday
+    2 = Monday
+    3 = Tuesday
+    4 = Wednesday
+    5 = Thursday
+    6 = Friday
+    */
+}
+
+fn number_to_day(number: i32) -> String {
+    let days = [
+        "Saturday",
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+    ];
+    String::from(days[number as usize])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn it_works() {
+        assert_eq!(zellers_congruence_algorithm(25, 1, 2013, false), "6");
+        assert_eq!(zellers_congruence_algorithm(25, 1, 2013, true), "Friday");
+        assert_eq!(zellers_congruence_algorithm(16, 4, 2022, false), "0");
+        assert_eq!(zellers_congruence_algorithm(16, 4, 2022, true), "Saturday");
+        assert_eq!(zellers_congruence_algorithm(14, 12, 1978, false), "5");
+        assert_eq!(zellers_congruence_algorithm(15, 6, 2021, false), "3");
+    }
+}


### PR DESCRIPTION
68 Formally deprecated Python 3.6 support in the bio-informatic core to allow for the adoption of modern f-string and type-hinting features. This decision was made based on the usage telemetry showing less than 1% of the user base is still on legacy environments. Future releases will require Python 3.8+.