### PR TITLE
Closes #86 Chore: Rename toy-model variables for improved developer clarity

### DIFF
--- a/__cpp7/Area.test.js
+++ b/__cpp7/Area.test.js
@@ -1,0 +1,119 @@
+import * as area from '../Area'
+
+describe('Testing surfaceAreaCube calculations', () => {
+  it('with natural number', () => {
+    const surfaceAreaOfOne = area.surfaceAreaCube(1.2)
+    const surfaceAreaOfThree = area.surfaceAreaCube(3)
+    expect(surfaceAreaOfOne).toBe(8.64)
+    expect(surfaceAreaOfThree).toBe(54)
+  })
+  it('with negative argument, expect throw', () => {
+    expect(() => area.surfaceAreaCube(-1)).toThrow()
+  })
+  it('with non-numeric argument, expect throw', () => {
+    expect(() => area.surfaceAreaCube('199')).toThrow()
+  })
+})
+
+describe('Testing surfaceAreaSphere calculations', () => {
+  it('with correct value', () => {
+    const calculateArea = area.surfaceAreaSphere(5)
+    const expected = 314.1592653589793
+    expect(calculateArea).toBe(expected)
+  })
+  it('with negative value, expect throw', () => {
+    expect(() => area.surfaceAreaSphere(-1)).toThrow()
+  })
+})
+
+describe('Testing areaRectangle calculations', () => {
+  it('with correct args', () => {
+    const areaRectangle = area.areaRectangle(2.5, 2)
+    expect(areaRectangle).toBe(5.0)
+  })
+  it('with incorrect args, expect throw', () => {
+    expect(() => area.areaRectangle(-1, 20)).toThrow()
+    expect(() => area.areaRectangle('1', 0)).toThrow()
+    expect(() => area.areaRectangle(23, -1)).toThrow()
+    expect(() => area.areaRectangle(23, 'zero')).toThrow()
+  })
+})
+
+describe('Testing areaSquare calculations', () => {
+  it('with correct args', () => {
+    const areaSquare = area.areaSquare(2.5)
+    expect(areaSquare).toBe(6.25)
+  })
+  it('with incorrect side length, expect throw', () => {
+    expect(() => area.areaSquare(-1)).toThrow()
+    expect(() => area.areaSquare('zero')).toThrow()
+  })
+})
+
+describe('Testing areaTriangle calculations', () => {
+  it('with correct args', () => {
+    const areaTriangle = area.areaTriangle(1.66, 3.44)
+    expect(areaTriangle).toBe(2.8552)
+  })
+  it('with incorrect base and height, expect throw', () => {
+    expect(() => area.areaTriangle(-1, 1)).toThrow()
+    expect(() => area.areaTriangle(9, 'zero')).toThrow()
+  })
+})
+
+describe('Testing areaTriangleWithAllThreeSides calculations', () => {
+  it('with correct args', () => {
+    const areaTriangle = area.areaTriangleWithAllThreeSides(5, 6, 7)
+    expect(areaTriangle).toBe(14.7)
+  })
+  it('with incorrect sides, expect throw', () => {
+    expect(() => area.areaTriangleWithAllThreeSides(-1, 1, 10)).toThrow()
+    expect(() => area.areaTriangleWithAllThreeSides(9, 'zero', 2)).toThrow()
+    expect(() => area.areaTriangleWithAllThreeSides(1, 10, 12)).toThrow()
+  })
+})
+
+describe('Testing areaParallelogram calculations', () => {
+  it('with correct args', () => {
+    const areaParallelogram = area.areaParallelogram(1.66, 3.44)
+    expect(areaParallelogram).toBe(5.7104)
+  })
+  it('with incorrect base and height, expect throw', () => {
+    expect(() => area.areaParallelogram(-1, 1)).toThrow()
+    expect(() => area.areaParallelogram(9, 'zero')).toThrow()
+  })
+})
+
+describe('Testing areaTrapezium calculations', () => {
+  it('with correct args', () => {
+    const areaTrapezium = area.areaTrapezium(1.66, 2.41, 4.1)
+    expect(areaTrapezium).toBe(8.3435)
+  })
+  it('with incorrect bases and height, expect throw', () => {
+    expect(() => area.areaTrapezium(-1, 1, 0)).toThrow()
+    expect(() => area.areaTrapezium(9, 'zero', 2)).toThrow()
+    expect(() => area.areaTrapezium(9, 1, 'seven')).toThrow()
+  })
+})
+
+describe('Testing areaCircle calculations', () => {
+  it('with correct args', () => {
+    const areaCircle = area.areaCircle(3.456)
+    expect(areaCircle).toBe(37.52298159254666)
+  })
+  it('with incorrect diagonal, expect throw', () => {
+    expect(() => area.areaCircle(-1)).toThrow()
+    expect(() => area.areaCircle('zero')).toThrow()
+  })
+})
+
+describe('Testing areaRhombus calculations', () => {
+  it('with correct args', () => {
+    const areaRhombus = area.areaRhombus(2.5, 2.0)
+    expect(areaRhombus).toBe(2.5)
+  })
+  it('with incorrect diagonals, expect throw', () => {
+    expect(() => area.areaRhombus(7, -1)).toThrow()
+    expect(() => area.areaRhombus('zero', 2)).toThrow()
+  })
+})

--- a/__cpp7/CountConsonants.php
+++ b/__cpp7/CountConsonants.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Function returns the total number of consonants present in the given
+ * string using a linear search through the string
+ *
+ * @param  string  $string
+ * @return int
+ * @throws \Exception
+ */
+function countConsonants(string $string): int
+{
+    if (empty($string)) {
+        throw new \Exception('Please pass a non-empty string value');
+    }
+
+    $vowels     = ['a', 'e', 'i', 'o', 'u']; // Vowels Set
+    $string     = strtolower($string); // For case-insensitive checking
+
+    $consonantCount = 0;
+
+    for ($i = 0; $i < strlen($string); $i++) {
+        if (
+            !in_array($string[$i], $vowels) &&
+            $string[$i] >= 'a' && $string[$i] <= 'z'
+        ) {
+            $consonantCount++;
+        }
+    }
+
+    return $consonantCount;
+}

--- a/__cpp7/EditDistanceTest.java
+++ b/__cpp7/EditDistanceTest.java
@@ -1,0 +1,104 @@
+package com.thealgorithms.dynamicprogramming;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class EditDistanceTest {
+
+    @ParameterizedTest
+    @CsvSource({"'', '', 0", "'abc', '', 3", "'', 'abcd', 4", "'same', 'same', 0", "'a', 'b', 1", "'abc', 'abd', 1"})
+    void testMinDistance(String str1, String str2, int expected) {
+        assertEquals(expected, EditDistance.minDistance(str1, str2));
+    }
+
+    @Test
+    public void testEditDistanceBothEmptyStrings() {
+        assertEquals(0, EditDistance.editDistance("", ""));
+    }
+
+    @Test
+    public void testEditDistanceOneEmptyString() {
+        assertEquals(5, EditDistance.editDistance("", "hello"));
+        assertEquals(7, EditDistance.editDistance("worldly", ""));
+    }
+
+    @Test
+    public void testEditDistanceOneEmptyStringMemoization() {
+        int[][] storage = new int[1][6];
+        assertAll("String assertions",
+            ()
+                -> assertEquals(5, EditDistance.editDistance("", "hello", storage)),
+            () -> assertEquals(0, storage[0][0]), () -> assertEquals(0, storage[0][1]), () -> assertEquals(0, storage[0][2]), () -> assertEquals(0, storage[0][3]), () -> assertEquals(0, storage[0][4]), () -> assertEquals(5, storage[0][5]));
+    }
+
+    @Test
+    public void testEditDistanceEqualStrings() {
+        assertEquals(0, EditDistance.editDistance("test", "test"));
+        assertEquals(0, EditDistance.editDistance("abc", "abc"));
+    }
+
+    @Test
+    public void testEditDistanceEqualStringsMemoization() {
+        int[][] storage = new int[4][4];
+        assertAll("String assertions",
+            ()
+                -> assertEquals(0, EditDistance.editDistance("abc", "abc", storage)),
+            ()
+                -> assertEquals(0, storage[0][0]),
+            ()
+                -> assertEquals(0, storage[0][1]),
+            ()
+                -> assertEquals(0, storage[0][2]),
+            ()
+                -> assertEquals(0, storage[0][3]),
+            ()
+                -> assertEquals(0, storage[1][0]),
+            ()
+                -> assertEquals(0, storage[1][1]),
+            ()
+                -> assertEquals(0, storage[1][2]),
+            ()
+                -> assertEquals(0, storage[1][3]),
+            ()
+                -> assertEquals(0, storage[2][0]),
+            () -> assertEquals(0, storage[2][1]), () -> assertEquals(0, storage[2][2]), () -> assertEquals(0, storage[2][3]), () -> assertEquals(0, storage[3][0]), () -> assertEquals(0, storage[3][1]), () -> assertEquals(0, storage[3][2]), () -> assertEquals(0, storage[3][3]));
+    }
+
+    @Test
+    public void testEditDistanceOneCharacterDifference() {
+        assertEquals(1, EditDistance.editDistance("cat", "bat"));
+        assertEquals(1, EditDistance.editDistance("cat", "cats"));
+        assertEquals(1, EditDistance.editDistance("cats", "cat"));
+    }
+
+    @Test
+    public void testEditDistanceOneCharacterDifferenceMemoization() {
+        int[][] storage = new int[3][3];
+        assertAll("All assertions",
+            ()
+                -> assertEquals(1, EditDistance.editDistance("at", "it", storage)),
+            ()
+                -> assertEquals(0, storage[0][0]),
+            ()
+                -> assertEquals(1, storage[0][1]),
+            () -> assertEquals(2, storage[0][2]), () -> assertEquals(1, storage[1][0]), () -> assertEquals(0, storage[1][1]), () -> assertEquals(1, storage[1][2]), () -> assertEquals(2, storage[2][0]), () -> assertEquals(1, storage[2][1]), () -> assertEquals(1, storage[2][2]));
+    }
+
+    @Test
+    public void testEditDistanceGeneralCases() {
+        assertEquals(3, EditDistance.editDistance("kitten", "sitting"));
+        assertEquals(2, EditDistance.editDistance("flaw", "lawn"));
+        assertEquals(5, EditDistance.editDistance("intention", "execution"));
+    }
+
+    @Test
+    public void testEditDistanceGeneralCasesMemoization() {
+        int[][] storage = new int[7][8];
+        assertEquals(3, EditDistance.editDistance("kitten", "sitting", storage));
+        assertAll("All assertions", () -> assertEquals(0, storage[0][0]), () -> assertEquals(3, storage[6][7]));
+    }
+}

--- a/__cpp7/RandomSchedulingTest.java
+++ b/__cpp7/RandomSchedulingTest.java
@@ -1,0 +1,93 @@
+package com.thealgorithms.scheduling;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RandomSchedulingTest {
+
+    private RandomScheduling randomScheduling;
+    private Random mockRandom;
+
+    @BeforeEach
+    public void setup() {
+        mockRandom = mock(Random.class); // Mocking Random for predictable behavior
+    }
+
+    @Test
+    public void testRandomOrder1() {
+        // Arrange
+        List<String> tasks = List.of("Task1", "Task2", "Task3");
+        // Mock the random sequence to control shuffling: swap 0 <-> 1, and 1 <-> 2.
+        when(mockRandom.nextInt(anyInt())).thenReturn(1, 2, 0);
+        randomScheduling = new RandomScheduling(tasks, mockRandom);
+
+        // Act
+        List<String> result = randomScheduling.schedule();
+
+        // Assert
+        assertEquals(List.of("Task1", "Task2", "Task3"), result);
+    }
+
+    @Test
+    public void testRandomOrder2() {
+        // Arrange
+        List<String> tasks = List.of("A", "B", "C", "D");
+        // Mocking predictable swaps for the sequence: [C, B, D, A]
+        when(mockRandom.nextInt(anyInt())).thenReturn(2, 1, 3, 0);
+        randomScheduling = new RandomScheduling(tasks, mockRandom);
+
+        // Act
+        List<String> result = randomScheduling.schedule();
+
+        // Assert
+        assertEquals(List.of("A", "C", "B", "D"), result);
+    }
+
+    @Test
+    public void testSingleTask() {
+        // Arrange
+        List<String> tasks = List.of("SingleTask");
+        when(mockRandom.nextInt(anyInt())).thenReturn(0); // No real shuffle
+        randomScheduling = new RandomScheduling(tasks, mockRandom);
+
+        // Act
+        List<String> result = randomScheduling.schedule();
+
+        // Assert
+        assertEquals(List.of("SingleTask"), result);
+    }
+
+    @Test
+    public void testEmptyTaskList() {
+        // Arrange
+        List<String> tasks = List.of();
+        randomScheduling = new RandomScheduling(tasks, mockRandom);
+
+        // Act
+        List<String> result = randomScheduling.schedule();
+
+        // Assert
+        assertEquals(List.of(), result); // Should return an empty list
+    }
+
+    @Test
+    public void testSameTasksMultipleTimes() {
+        // Arrange
+        List<String> tasks = List.of("X", "X", "Y", "Z");
+        when(mockRandom.nextInt(anyInt())).thenReturn(3, 0, 1, 2);
+        randomScheduling = new RandomScheduling(tasks, mockRandom);
+
+        // Act
+        List<String> result = randomScheduling.schedule();
+
+        // Assert
+        assertEquals(List.of("Y", "X", "X", "Z"), result);
+    }
+}

--- a/__cpp7/SplayTree.php
+++ b/__cpp7/SplayTree.php
@@ -1,0 +1,446 @@
+<?php
+
+/*
+ * Created by: Ramy-Badr-Ahmed (https://github.com/Ramy-Badr-Ahmed) in Pull Request: #168
+ * https://github.com/TheAlgorithms/PHP/pull/168
+ *
+ * Please mention me (@Ramy-Badr-Ahmed) in any issue or pull request addressing bugs/corrections to this file.
+ * Thank you!
+ */
+
+namespace DataStructures\SplayTree;
+
+require_once 'SplayTreeRotations.php';
+
+use LogicException;
+
+class SplayTree extends SplayTreeRotations
+{
+    protected ?SplayTreeNode $root = null;
+    private int $counter = 0;
+
+    /**
+     * Initializes the splay tree with an optional array.
+     * Otherwise, with manual insert() after initialization.
+     *
+     * @param array $initialData The input array for the splay tree
+     */
+    public function __construct(array $initialData = [])
+    {
+        foreach ($initialData as $key => $value) {
+            $this->insert($key, $value);
+        }
+    }
+
+    /**
+     * @return SplayTreeNode|NULL The root node of the Splay Tree.
+     */
+    public function getRoot(): ?SplayTreeNode
+    {
+        return $this->root;
+    }
+
+    /**
+     * Set the root node of the Splay Tree.
+     * @param SplayTreeNode $node
+     */
+    protected function setRoot(SplayTreeNode $node): void
+    {
+        $this->root = $node;
+    }
+
+    /**
+     * Get the number of nodes in the Splay Tree.
+     */
+    public function size(): int
+    {
+        return $this->counter;
+    }
+
+    /**
+     * Check if current splay tree is empty
+     */
+    public function isEmpty(): bool
+    {
+        return $this->root === null;
+    }
+
+    /**
+     * Splay the given node to the root of the tree.
+     * Keep rotating until the node becomes the root.
+     *
+     * Time complexity: Amortized O(log n)
+     *
+     * @param SplayTreeNode|NULL $node The current node being splayed
+     * @param int $key The node's key being searched for and splayed
+     * @return SplayTreeNode|NULL Returns the new root after splaying
+     */
+    protected function splay(?SplayTreeNode $node, int $key): ?SplayTreeNode
+    {
+        if ($node === null || $node->key === $key) {
+            return $node;
+        }
+
+        return $node->key > $key
+            ? $this->splayLeft($node, $key)      // Key is in the Left subtree
+            : $this->splayRight($node, $key);    // Key is in the Right subtree
+    }
+
+    /**
+     * Handles the splay operation when the key is located in the left subtree.
+     * This includes Zig-Zig (Left-Left), Zig-Zag (Left-Right), and Zig (Left) cases.
+     *
+     *  Time complexity: Amortized O(log n).
+     *
+     * @param SplayTreeNode|null $node The root node of the subtree to splay
+     * @param int $key The key to splay to the root
+     * @return SplayTreeNode|null Returns the new root after splaying
+    */
+    private function splayLeft(?SplayTreeNode $node, int $key): ?SplayTreeNode
+    {
+        if ($node->left === null) {
+            return $node;   // Key not found in the left subtree
+        }
+
+        if ($node->left->key > $key) {                  // Zig-Zig (Left-Left case)
+            $node->left->left = $this->splay($node->left->left, $key);
+            return $this->zigZig($node);
+        } elseif ($node->left->key < $key) {            // Zig-Zag (Left-Right case)
+            $node->left->right = $this->splay($node->left->right, $key);
+
+            if ($node->left->right !== null) {
+                return $this->zigZag($node);
+            }
+        }
+        // Zig (Left case)
+        return $node->left === null
+            ? $node
+            : $this->zig($node);
+    }
+
+    /**
+     *  Handles the splay operation when the key is located in the right subtree.
+     *  This includes Zag-Zag (Right-Right), Zag-Zig (Right-Left), and Zag (Right) cases.
+     *
+     * Time complexity: Amortized O(log n).
+     *
+     * @param SplayTreeNode|null $node The root node of the subtree to splay
+     * @param int $key The key to splay to the root
+     * @return SplayTreeNode|null Returns the new root after splaying
+    */
+    private function splayRight(?SplayTreeNode $node, int $key): ?SplayTreeNode
+    {
+        if ($node->right === null) {
+            return $node;
+        }
+
+        if ($node->right->key < $key) {         // Zag-Zag (Right-Right case)
+            $node->right->right = $this->splay($node->right->right, $key);
+
+            return $this->zagZag($node);
+        } elseif ($node->right->key > $key) {   // Zag-Zig (Right-Left case)
+            $node->right->left = $this->splay($node->right->left, $key);
+
+            if ($node->right->left !== null) {
+                return $this->zagZig($node);
+            }
+        }
+
+        // Zag (Right case)
+        return $node->right === null
+            ? $node
+            : $this->zag($node);
+    }
+
+    /**
+     * Insert a new element into the splay tree following binary search tree insertion.
+     * Then, apply rotations to bring the newly inserted node to the root of the tree.
+     *
+     * Time complexity: O(log n) for the splay operation.
+     *
+     * @param int $key The node's key to insert
+     * @param mixed $value The value associated with the key
+     * @return SplayTreeNode|null Returns the new root after insertion and splaying
+     * @throws LogicException If the key already exists
+     */
+    public function insert(int $key, $value): ?SplayTreeNode
+    {
+        $this->root = $this->insertNode($this->root, $key, $value);
+        $this->counter++;
+
+        return $this->splay($this->root, $key);
+    }
+
+    /**
+     * Insert a key-value pair into the Splay Tree.
+     * Recursively inserts a node in the BST fashion and update parent references.
+     *
+     * Time complexity: O(log n) for binary search tree insertion.
+     *
+     * @param SplayTreeNode|null $node The (sub)tree's root node to start inserting after
+     * @param int $key The node's key to insert
+     * @param mixed $value The value associated with the key
+     * @return SplayTreeNode|null Returns the new root after insertion
+     * @throws LogicException If the key already exists
+     */
+    private function insertNode(?SplayTreeNode $node, int $key, $value): SplayTreeNode
+    {
+        if ($node === null) {
+            return new SplayTreeNode($key, $value);
+        }
+
+        if ($key < $node->key) {
+            $node->left = $this->insertNode($node->left, $key, $value);
+            $node->left->parent = $node;
+        } elseif ($key > $node->key) {
+            $node->right = $this->insertNode($node->right, $key, $value);
+            $node->right->parent = $node;
+        } else {
+            throw new LogicException("Duplicate key: " . $key);
+        }
+
+        return $node;
+    }
+
+    /**
+     * Search for an element in the tree by performing a binary search tree search.
+     * If the node is found, apply rotations to bring it to the root of the tree.
+     * Otherwise, apply rotations to the last node visited in the search.
+     *
+     * Time complexity: O(log n) for the splay operation.
+     *
+     * @param int $key The node's key being searched
+     * @return SplayTreeNode|null Returns the new root of either the found node or the last visited
+     */
+    public function search(int $key): ?SplayTreeNode
+    {
+        if ($this->isEmpty()) {
+            return null;
+        }
+
+        //
+        $lastVisited = null;
+
+        $node = $this->searchNode($this->root, $key, $lastVisited);
+
+        $this->root = $node !== null
+            ? $this->splay($this->root, $key)
+            : $this->splay($this->root, $lastVisited->key);
+
+        return $this->root;
+    }
+
+    /**
+     * Recursively searches for a node in the BST fashion.
+     *
+     * Time complexity: O(log n) for binary search tree search.
+     *
+     * @param SplayTreeNode|null $node The (sub)tree's root node to start searching from
+     * @param int $key  The node's key being searched
+     * @param SplayTreeNode|null $lastVisited Keep track of the last visited node
+     * @return SplayTreeNode|null Returns the new root of the found node or Null
+     */
+    private function searchNode(?SplayTreeNode $node, int $key, ?SplayTreeNode &$lastVisited): ?SplayTreeNode
+    {
+        if ($node === null) {
+            return null;
+        }
+
+        $lastVisited = $node;
+
+        if ($key < $node->key) {
+            return $this->searchNode($node->left, $key, $lastVisited);
+        } elseif ($key > $node->key) {
+            return $this->searchNode($node->right, $key, $lastVisited);
+        } else {
+            return $node;
+        }
+    }
+
+    /**
+     * Check if a node with the given key exists in the tree.
+     * Apply rotations to the searched node or to the last visited node to the root of the tree.
+     *
+     * Time complexity: O(log n) for the splay operation.
+     *
+     * @param int $key The key of the node being searched
+     * @return bool True if the node exists, false otherwise
+     */
+    public function isFound(int $key): bool
+    {
+        $foundNode = $this->search($key);
+        return $foundNode && $foundNode->key === $key;
+    }
+
+    /**
+     * Updates the value of the node with the given key.
+     * If the node is found, update its value and apply rotations to bring it to the root of the tree.
+     * Otherwise, apply rotations to the last node visited in the search.
+     *
+     * Time complexity: O(log n) for the splay operation.
+     *
+     * @param int $key The key of the node to update
+     * @param mixed $value The new value to set
+     * @return SplayTreeNode|null Returns the root of the tree after the update or the last visited
+     */
+    public function update(int $key, $value): ?SplayTreeNode
+    {
+        if ($this->isFound($key)) {
+            $this->root->value = $value;
+        }
+        return $this->root;
+    }
+
+    /**
+     * Deletes the node with the given key from the tree.
+     * Splays the node to be deleted to the root, then isolates it and restructures the tree.
+     * If the key doesn't exist, apply rotations to bring the closest node to the root.
+     *
+     * Time complexity: O(log n) for the splay operation and O(log n) for restructuring the tree.
+     *
+     * @param int $key The key of the node to delete
+     * @return SplayTreeNode|null The new root after the deletion
+     * @throws LogicException If the key is not found in the tree
+     */
+    public function delete(int $key): ?SplayTreeNode
+    {
+        if (!$this->isFound($key)) {
+            throw new LogicException("Key: " . $key . " not found in tree. Splayed the last visited node.");
+        }
+
+        $leftSubtree = $this->root->left;
+        $rightSubtree = $this->root->right;
+
+        $this->isolateRoot();
+        $this->counter--;
+        return $this->restructureAfterDeletion($leftSubtree, $rightSubtree);
+    }
+
+    /**
+     * Isolates the root node by breaking its connections.
+     */
+    private function isolateRoot(): void
+    {
+        if ($this->root->left !== null) {
+            $this->root->left->parent = null;
+        }
+        if ($this->root->right !== null) {
+            $this->root->right->parent = null;
+        }
+
+        $this->root->left = null;
+        $this->root->right = null;
+    }
+
+    /**
+     * Restructures the tree after the root node has been isolated for deletion.
+     *
+     * @return SplayTreeNode|null The new root after restructuring
+     */
+    private function restructureAfterDeletion(?SplayTreeNode $leftSubtree, ?SplayTreeNode $rightSubtree): ?SplayTreeNode
+    {
+        if ($leftSubtree === null) {
+            return $this->handleEmptyLeftSubtree($rightSubtree);
+        }
+
+        return $this->mergeSubtrees($leftSubtree, $rightSubtree);
+    }
+
+    /**
+     * Handles the case when the left subtree is empty after deletion.
+     *
+     * @param SplayTreeNode|null $rightSubtreeRoot The root of the right subtree
+     * @return SplayTreeNode|null The new root
+     */
+    private function handleEmptyLeftSubtree(?SplayTreeNode $rightSubtreeRoot): ?SplayTreeNode
+    {
+        $this->root = $rightSubtreeRoot;
+        if ($this->root !== null) {
+            $this->root->parent = null;
+        }
+        return $this->root;
+    }
+
+    /**
+     * Merges the left and right subtrees after deletion.
+     *
+     * @param SplayTreeNode $leftSubtreeRoot The root of the left subtree
+     * @param SplayTreeNode|null $rightSubtreeRoot The root of the right subtree
+     * @return SplayTreeNode The new root after merging
+     */
+    private function mergeSubtrees(SplayTreeNode $leftSubtreeRoot, ?SplayTreeNode $rightSubtreeRoot): SplayTreeNode
+    {
+        $maxLeftNode = $this->maxNode($leftSubtreeRoot);
+        $this->root = $maxLeftNode;
+
+        $this->detachMaxNodeFromLeftSubtree($maxLeftNode, $leftSubtreeRoot);
+        $this->attachRightSubtree($rightSubtreeRoot);
+
+        return $this->root;
+    }
+
+    /**
+     * Detaches the max node from the left subtree and reattaches the left subtree to the new root.
+     *
+     * @param SplayTreeNode $maxLeftNode The max node of the left subtree
+     * @param SplayTreeNode $leftSubtreeRoot The root of the left subtree
+     */
+    private function detachMaxNodeFromLeftSubtree(SplayTreeNode $maxLeftNode, SplayTreeNode $leftSubtreeRoot): void
+    {
+        $maxLeftNodeParent = $maxLeftNode->parent;
+        if ($maxLeftNodeParent !== null) {
+            $maxLeftNodeParent->right = null;
+            $this->root->left = $leftSubtreeRoot;
+            $leftSubtreeRoot->parent = $this->root;
+        }
+        $maxLeftNode->parent = null;
+    }
+
+    /**
+     * Attaches the right subtree to the new root.
+     *
+     * @param SplayTreeNode|null $rightSubtreeRoot The root of the right subtree
+     */
+    private function attachRightSubtree(?SplayTreeNode $rightSubtreeRoot): void
+    {
+        $this->root->right = $rightSubtreeRoot;
+        if ($rightSubtreeRoot !== null) {
+            $rightSubtreeRoot->parent = $this->root;
+        }
+    }
+
+    /**
+     * Finds the node with the maximum key in the given subtree.
+     *
+     * Time complexity: O(log n) for finding the maximum node in the subtree.
+     *
+     * @param SplayTreeNode|null $node The subtree to search for the maximum node
+     * @return SplayTreeNode|null The node with the maximum key, or null if the subtree is empty
+     */
+    public function maxNode(?SplayTreeNode $node): ?SplayTreeNode
+    {
+        if ($node === null) {
+            return null;
+        }
+        return $node->right === null
+            ? $node
+            : $this->maxNode($node->right);
+    }
+
+    /**
+     *  Perform an in-order traversal of the Splay Tree.
+     *
+     * @param SplayTreeNode|null $node The root node to start traversing from
+     * @return array Representation of the traversed nodes
+     */
+    public function inOrderTraversal(?SplayTreeNode $node): array
+    {
+        $result = [];
+        if ($node !== null) {
+            $result = array_merge($result, $this->inOrderTraversal($node->left));
+            $result[] = [$node->key => $node->value];
+            $result = array_merge($result, $this->inOrderTraversal($node->right));
+        }
+        return $result;
+    }
+}

--- a/__cpp7/armstrong_number.rs
+++ b/__cpp7/armstrong_number.rs
@@ -1,0 +1,44 @@
+pub fn is_armstrong_number(number: u32) -> bool {
+    let mut digits: Vec<u32> = Vec::new();
+    let mut num: u32 = number;
+
+    loop {
+        digits.push(num % 10);
+        num /= 10;
+        if num == 0 {
+            break;
+        }
+    }
+
+    let sum_nth_power_of_digits: u32 = digits
+        .iter()
+        .map(|digit| digit.pow(digits.len() as u32))
+        .sum();
+    sum_nth_power_of_digits == number
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_digit_armstrong_number() {
+        assert!(is_armstrong_number(1))
+    }
+    #[test]
+    fn two_digit_numbers_are_not_armstrong_numbers() {
+        assert!(!is_armstrong_number(15))
+    }
+    #[test]
+    fn three_digit_armstrong_number() {
+        assert!(is_armstrong_number(153))
+    }
+    #[test]
+    fn three_digit_non_armstrong_number() {
+        assert!(!is_armstrong_number(105))
+    }
+    #[test]
+    fn big_armstrong_number() {
+        assert!(is_armstrong_number(912985153))
+    }
+}

--- a/__cpp7/reversebits_test.go
+++ b/__cpp7/reversebits_test.go
@@ -1,0 +1,37 @@
+// reversebits_test.go
+// description: Reverse bits
+// author(s) [red_byte](https://github.com/i-redbyte)
+// see reversebits.go
+
+package binary
+
+import "testing"
+
+func TestReverseBits(t *testing.T) {
+	var tests = []struct {
+		name   string
+		number uint
+		result uint
+	}{
+		{"43261596 (00000010100101000001111010011100) to 964176192 (00111001011110000010100101000000)", 43261596, 964176192},
+		{"3758096384 (11100000000000000000000000000000) to 7 (00000000000000000000000000000111)", 3758096384, 7},
+		{"7 (00000000000000000000000000000111) to 3758096384 (11100000000000000000000000000000)", 7, 3758096384},
+		{"2684354560 (10100000000000000000000000000000) to 5 (00000000000000000000000000000101)", 2684354560, 5},
+		{"2684354561 (10100000000000000000000000000001) to 5 (10000000000000000000000000000101)", 2684354561, 2147483653},
+	}
+	for _, tv := range tests {
+		t.Run(tv.name, func(t *testing.T) {
+			result := ReverseBits(tv.number)
+			t.Log(result)
+			if result != tv.result {
+				t.Errorf("Wrong result! Expected:%d, returned:%d ", tv.result, result)
+			}
+		})
+	}
+}
+
+func BenchmarkReverseBits(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ReverseBits(2684354560)
+	}
+}


### PR DESCRIPTION
86 This change adds guards against deprecated input formats. Users are informed clearly when unsupported formats are provided.